### PR TITLE
Sobreescribiendo la librería que retorna {% elections_json %} y que i…

### DIFF
--- a/votai_theme/templatetags/yqs_extras.py
+++ b/votai_theme/templatetags/yqs_extras.py
@@ -1,0 +1,27 @@
+from django import template
+
+register = template.Library()
+
+from django.utils.safestring import mark_safe
+from elections.models import Election
+import json
+from django.core.urlresolvers import reverse
+
+
+@register.simple_tag
+def elections_json():
+    expected_elections = []
+    for election in Election.objects.filter(searchable=True):
+        tags = []
+        for tag in election.tags.all():
+            tags.append(tag.name)
+
+        election_dict = {
+            'name': election.name,
+            'slug': election.slug,
+            'detaillink': election.get_absolute_url(),
+            'medianaranja_link': reverse('soul_mate_detail_view_json', kwargs={'slug': election.slug}),
+            'tags': tags
+        }
+        expected_elections.append(election_dict)
+    return mark_safe(json.dumps(expected_elections))


### PR DESCRIPTION
Hola!
Este PR agrega una libreria de templates o [templatetags](https://docs.djangoproject.com/en/1.8/howto/custom-template-tags/) que sobreescribe una que tenía el VI y que retornaba la url de una elección. Ahora también retorna desde dónde debemos sacar el JSON para la media naranja. El json retornado viene así:

```
[
    {
    "medianaranja_link": "/theme/election/presidencial/media-naranja.json", 
    "tags": [], 
    "name": "Presidencial", 
    "detaillink": "/election/presidencial", 
    "slug": "presidencial"
    },
    {
    "medianaranja_link": "/theme/election/vice-presidencial/media-naranja.json", 
    "tags": [], 
    "name": "Vice-Presidencial", 
    "detaillink": "/election/vice-presidencial", 
    "slug": "vice=presidencial"
    }
]
```

Cómo funciona? en los templates tienes que agregar esta linea al principio:
`{% load yqs_extras %}`. Si es que en el template está presente la librería `{% load votainteligente_extras %}` entonces `{% load yqs_extras %}` debe ir después para sobre_escribir. Por ejemplo en [esta linea](https://github.com/YoQuieroSaber/votai-theme/blob/master/votai_theme/templates/base.html#L6).

Luego la invocas así `{% elections_json %}`
